### PR TITLE
puppet 4.4 requires full path on exec statements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@ class letsencrypt_nginx (
   }
 
   exec{ 'set letsencrypt_nginx_firstrun fact':
-    command     => 'mkdir -p /etc/facter/facts.d/ && echo "letsencrypt_nginx_firstrun=SUCCESS" > /etc/facter/facts.d/letsencrypt_nginx.txt',
+    command     => '/bin/mkdir -p /etc/facter/facts.d/ && echo "letsencrypt_nginx_firstrun=SUCCESS" > /etc/facter/facts.d/letsencrypt_nginx.txt',
     refreshonly => true,
   }
 


### PR DESCRIPTION
Puppet 4.4 was complaining about unqualified paths in exec {}. 
Small change to add qualified path.
